### PR TITLE
Add cross platform release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ release: clean ## package and upload a release
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload
 
-dist: clean ## builds source and wheel package
+dist: clean pyinstaller dist/swim ## builds source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist
@@ -99,3 +99,26 @@ docker_build:
 
 docker_push:
 	docker push mwort/swim:latest
+
+# Creates a single executable for a given platform, using swimpy/scripts/swimpy as the entrypoint
+# Meant to be ran in a venv or docker container
+pyinstaller: ## build single executable for swimpy
+	pip install pyinstaller
+	pip install -e .
+	pip install -r requirements_dev.txt
+	pyinstaller \
+		-p dependencies/modelmanager \
+		-p dependencies/m.swim \
+		-p . \
+		-F \
+		--collect-submodules dependencies \
+		-d noarchive \
+		--add-data dependencies/modelmanager/modelmanager/:modelmanager \
+		swimpy/scripts/swimpy
+
+dependencies/swim/code/swim:
+	make -C dependencies/swim/code
+
+dist/swim: dependencies/swim/code/swim
+	mkdir -p dist/
+	cp dependencies/swim/code/swim dist/swim

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ export PRINT_HELP_PYSCRIPT
 
 BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
+ifeq ($(OS),Windows_NT)
+	FILE_SEP=";"
+else
+	FILE_SEP=":"
+endif
+
 help:
 	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
@@ -113,7 +119,7 @@ pyinstaller: ## build single executable for swimpy
 		-F \
 		--collect-submodules dependencies \
 		-d noarchive \
-		--add-data dependencies/modelmanager/modelmanager/:modelmanager \
+		--add-data dependencies/modelmanager/modelmanager/$(FILE_SEP)modelmanager \
 		swimpy/scripts/swimpy
 
 dependencies/swim/code/swim:

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ dist/swimpy: ## build single executable for swimpy
 
 # Creates a single executable for a given platform, using swimpy/scripts/swimpy-dashboard as the entrypoint
 # Meant to be created in a venv or docker container
-dist/swimpy-dashboard: ## build single executable for `swimpy dashboard start`
+dist/swimpy-dashboard: dependencies/swim/code/swim ## build single executable for `swimpy dashboard start`
 	pip install pyinstaller
 	pip install -e .[dashboard]
 	pip install -r requirements_dev.txt

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ release: clean ## package and upload a release
 	python setup.py sdist upload
 	python setup.py bdist_wheel upload
 
-dist: clean pyinstaller dist/swim ## builds source and wheel package
+dist: clean dist/swimpy dist/swim dist/swimpy-dashboard ## builds source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist
@@ -108,7 +108,7 @@ docker_push:
 
 # Creates a single executable for a given platform, using swimpy/scripts/swimpy as the entrypoint
 # Meant to be ran in a venv or docker container
-pyinstaller: ## build single executable for swimpy
+dist/swimpy: ## build single executable for swimpy
 	pip install pyinstaller
 	pip install -e .
 	pip install -r requirements_dev.txt
@@ -121,6 +121,25 @@ pyinstaller: ## build single executable for swimpy
 		-d noarchive \
 		--add-data dependencies/modelmanager/modelmanager/$(FILE_SEP)modelmanager \
 		swimpy/scripts/swimpy
+
+# Creates a single executable for a given platform, using swimpy/scripts/swimpy-dashboard as the entrypoint
+# Meant to be created in a venv or docker container
+dist/swimpy-dashboard: ## build single executable for `swimpy dashboard start`
+	pip install pyinstaller
+	pip install -e .[dashboard]
+	pip install -r requirements_dev.txt
+	pyinstaller \
+		-p dependencies/modelmanager \
+		-p dependencies/m.swim \
+		-p . \
+		-F \
+		--collect-submodules dependencies \
+		-d noarchive \
+		--add-data dependencies/modelmanager/modelmanager/$(FILE_SEP)modelmanager \
+		--add-data swimpy/$(FILE_SEP)swimpy/ \
+		--add-data dependencies/swim/$(FILE_SEP)dependencie/swim/ \
+		swimpy/scripts/swimpy-dashboard
+
 
 dependencies/swim/code/swim:
 	make -C dependencies/swim/code

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ A python package to interact and test the ecohydrological model SWIM.
 Quickstart
 ----------
 
-1. Setup python environment ``$ virtualenv swimpyenv`` and activate it
+1. [Install Python](./docs/install-python.md)
+2. Setup python environment ``$ virtualenv swimpyenv`` and activate it
    ``$ source swimpyenv/bin/activate``
-2. Download and install SWIMpy:
+3. Download and install SWIMpy:
    ``$ pip install git+https://gitlab.pik-potsdam.de/wortmann/swimpy.git``
-3. Setup your project in your model directory: ``$ swimpy setup``
-4. Check the commandline help ``swimpy -h``, use your project in python
+4. Setup your project in your model directory: ``$ swimpy setup``
+5. Check the commandline help ``swimpy -h``, use your project in python
    scripts by importing ``swimpy`` and loading the project instance:
    ``project = swimpy.Project()`` or by starting the browser app
    ``$ swimpy browser start`` and navigate your browser to [http://localhost:8000](http://localhost:8000)
@@ -36,6 +37,6 @@ Features
 * Easy parameter reading/setting and output file reading
 * Result visualisation with reusable matplotlib plot functions
 * Interface to GRASS database
-* Linking to the 
+* Linking to the
   [evoalgos](https://ls11-www.cs.tu-dortmund.de/people/swessing/evoalgos/doc/index.html)
   multiobjective evolutionary optimization package

--- a/docs/install-python.md
+++ b/docs/install-python.md
@@ -1,0 +1,45 @@
+# Installing Python
+
+## Windows
+
+### Windows Store
+
+You can open install python through the windows store.
+This is also the default when running `python` in the terminal, which
+will re-direct you to the windows store if python isn't currently installed.
+
+Search for "python" in the windows store and and you should be able to find
+a recent version of python.
+
+However, this is just a base installation of python, you will also need to download
+pip; which is the most commonly used package manager for python.
+```
+py -m ensurepip --default-pip
+```
+
+A full guide on install pip [is available in this installation guide](https://packaging.python.org/en/latest/tutorials/installing-packages/).
+
+### Official Python Installer
+
+The [official python releases for windows](https://www.python.org/downloads/windows/)
+will have many options for installation. The easist of which will be "Windows installer"
+which will be a guided installer.
+
+Depending on how your system's PATH is configured, the `python` command may still default
+to the `python` command stub which references the windows store.
+
+### Anaconda
+
+Anaconda is a popular python distribution platform, especially amongst the science community.
+Their [official installer page](https://www.anaconda.com/products/distribution) will provide
+you with an installer and many other necesities such as pip.
+
+## MacOS
+
+MacOS comes pre-installed with python and pip. One note is that `python` still defaults to
+python2 on MacOS. So explicit usage of `python3` is required to select python 3.
+
+## Linux
+
+`python3` is likely to be installed on most linux platforms as it's a commonly bundled tool with most
+distributions. Please refer to your respective distribution's documentation on how to install python.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,59 @@
+# Release Management
+
+## Create a New Relase
+
+### Increment Version
+
+Open `swimpy/__init__.py` and increment the `__version__` value within the file.
+
+### Release Birtual Environment
+
+Create a virtual environment (if not already in one):
+```
+python -m venv release-env
+source ./release-env/bin/activate
+```
+
+Install Dependencies:
+```
+pip install -e .
+```
+
+### Create Release artifacts
+
+From the top directory, run:
+```
+make dist
+```
+
+This should create a `dist/` directory with similar contents:
+
+```
+$ tree dist/
+dist/
+├── swim
+├── swimpy
+├── swimpy-0.5.0-py2.py3-none-any.whl
+└── swimpy-0.5.0.tar.gz
+```
+
+`swim` and `swimpy` are compiled, and will need to be compiled per platform (e.g. MacOS, Windows, Linux).
+
+### Upload to Pypi sdist and wheel
+
+```
+make release
+```
+
+### Push docker images
+
+Create Images:
+```
+make docker_build
+```
+
+Push Images
+```
+make docker_push
+```
+

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     test_suite='tests',
     tests_require=requirements_dev,
     setup_requires=requirements,
-    extra_requires={
+    extras_require={
         "dashboard": [
             "dash",
             "dash_bootstrap_components",

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
     ],
-    scripts=['swimpy/scripts/swimpy'],
+    scripts=['swimpy/scripts/swimpy', 'swimpy/scripts/swimpy-dashboard'],
     test_suite='tests',
     tests_require=requirements_dev,
     setup_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,10 @@ import codecs
 from setuptools import setup, find_packages
 
 requirements = [
-    "pandas>=0.23.4",
-    "django>=1.11.20, >=3.0",
-    "parse>=1.9, <2.0",
-    "matplotlib>=2.2.3",
+    "pandas>=1.0, <2",
+    "django>=1.11.20, <2",
+    "parse>=1.8, <2.0",
+    "matplotlib>=3.0, <4",
     "model-manager>=0.7",
     "f90nml>=1.0.2",
     "evoalgos>=1.0"

--- a/swimpy/scripts/swimpy-dashboard
+++ b/swimpy/scripts/swimpy-dashboard
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+from modelmanager import project, settings, commandline
+from swimpy.project import Project, setup
+import swimpy
+import sys
+
+description = (
+    'SWIMpy commandline interface\n\nDocumentation: %s' % swimpy.__docs__
+)
+
+if __name__ == '__main__':
+    # This is a bit of a hack, but mutating sys.argv avoids having to restructure
+    # argument passing
+    sys.argv.extend(["-p", "dependencies/swim/project","dashboard", "start"])
+    commandline.CommandlineInterface(
+        Project, description=description, setup=setup).run()


### PR DESCRIPTION
Some notes:

~~- Django 1.11 isn't compatible with python 3.10~~
~~- Pandas 0.22 doesn't have prebuilt wheels for python 3.7+, thus resorts to attempting a source installation~~

I have since updated the dependencies bounds and did some preliminary testing to make sure there weren't any regressions.

The updated bounds should make the interpreter incompatibilities I previously experienced largely irrelevant.